### PR TITLE
Fixing links to StarlingX governance

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -44,7 +44,7 @@ The StarlingX project is governed according to the “four opens”:
   <li>Open Community</li>
 </ul>
 
-Technical decisions will be made by technical contributors and a representative Technical Steering Committee. The community is committed to diversity, openness, encouraging new contributors and leaders to rise up. Current information is available at [wiki.openstack.org/wiki/Starlingx/Initial_Governance](//wiki.openstack.org/wiki/Starlingx/Initial_Governance).
+Technical decisions will be made by technical contributors and a representative Technical Steering Committee. The community is committed to diversity, openness, encouraging new contributors and leaders to rise up. Current information is available at [wiki.openstack.org/wiki/Starlingx/Initial_Governance](https://docs.starlingx.io/governance/index.html).
 
 ---
 

--- a/site/faq/index.md
+++ b/site/faq/index.md
@@ -46,7 +46,7 @@ The [StarlingX wiki](https://wiki.openstack.org/wiki/StarlingX) contains documen
 
 #### How is StarlingX governed?
 
-The proposed governance for StarlingX is here:[wiki.openstack.org/wiki/Starlingx/Initial_Governance](//wiki.openstack.org/wiki/Starlingx/Initial_Governance).
+The proposed governance for StarlingX is here:[wiki.openstack.org/wiki/Starlingx/Initial_Governance](https://docs.starlingx.io/governance/index.html).
 
 #### Are there StarlingX meetings?
 


### PR DESCRIPTION
The community has moved the governance documents to the docs.starlingx.io
website and this change updates the corresponding references on the
starlingx.io website.

Closes: #3