### PR TITLE
Fix governance hyperlink

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -44,7 +44,7 @@ The StarlingX project is governed according to the “four opens”:
   <li>Open Community</li>
 </ul>
 
-Technical decisions will be made by technical contributors and a representative Technical Steering Committee. The community is committed to diversity, openness, encouraging new contributors and leaders to rise up. Current information is available at [wiki.openstack.org/wiki/Starlingx/Initial_Governance](https://docs.starlingx.io/governance/index.html).
+Technical decisions will be made by technical contributors and a representative Technical Steering Committee. The community is committed to diversity, openness, encouraging new contributors and leaders to rise up. Current information is available in the [Governance section of the StarlingX Documentation website](https://docs.starlingx.io/governance/index.html).
 
 ---
 

--- a/site/faq/index.md
+++ b/site/faq/index.md
@@ -46,7 +46,7 @@ The [StarlingX wiki](https://wiki.openstack.org/wiki/StarlingX) contains documen
 
 #### How is StarlingX governed?
 
-The proposed governance for StarlingX is here:[wiki.openstack.org/wiki/Starlingx/Initial_Governance](https://docs.starlingx.io/governance/index.html).
+The information about governance including the TSC charter is available in the [Governance section of the StarlingX Documentation website](https://docs.starlingx.io/governance/index.html).
 
 #### Are there StarlingX meetings?
 


### PR DESCRIPTION
The links to the governance documentation was updated but the reference
text remained the old information. This patch fixes that.