### PR TITLE
Add group photo to blog post

### DIFF
--- a/site/blog/starlingx-meetup-january-2019.md
+++ b/site/blog/starlingx-meetup-january-2019.md
@@ -9,6 +9,8 @@ Check out the main discussion topics from the first StarlingX face to face plann
 
 As the StarlingX project is still in its infancy, it's crucial to have face time that developers as well as leaders can use to discuss both technical and process related matters to ensure the community has a balanced ecosystem and clear roadmap to execute on. To start the year with a clear focus, the community held its first [Contributor Meetup](https://etherpad.openstack.org/p/stx-chandler-meetup) event hosted by Intel in Chandler, Arizona on January 15-16.
 
+![alt text][/images/StarlingX_Contributor_Meetup_January_2019.jpg]
+
 During the two-day event the attendees discussed - both in person and remotely -  a wide range of topics from release planning through documentation and testing to onboarding. I'd like to give you a short summary of the main topics (as I remember them!) so that you can get up to speed and get involved.
 
 ## Release Planning
@@ -59,6 +61,7 @@ It's a high priority item for the community to reach out to new users as well as
 ## Elections
 
 As the community is setting up the governance models, members decided to choose leaders through an election process. The first election is scheduled for the second quarter of 2019 where five of the Technical Steering Committee (TSC) seats will be up for election. If you're interested in running for the TSC elections, make sure that you are actively participating so the community gets to know you. We're still working on the election process and exact dates, you can check the [governance web page](https://docs.starlingx.io/governance/reference/tsc/index.html) for updates.
+
 
 That's all for my summary. While it may seem like a long list, we had even more discussions and brainstorming sessions over the two days of the meetup. If you have any questions to the above items or if you're interested in trying out the software or getting involved in the community please [reach out](https://www.starlingx.io/community/) on the mailing list or IRC or join one of the weekly community meetings. You can find further details and pointers on the [StarlingX website](https://www.starlingx.io).
 

--- a/site/blog/starlingx-meetup-january-2019.md
+++ b/site/blog/starlingx-meetup-january-2019.md
@@ -9,7 +9,7 @@ Check out the main discussion topics from the first StarlingX face to face plann
 
 As the StarlingX project is still in its infancy, it's crucial to have face time that developers as well as leaders can use to discuss both technical and process related matters to ensure the community has a balanced ecosystem and clear roadmap to execute on. To start the year with a clear focus, the community held its first [Contributor Meetup](https://etherpad.openstack.org/p/stx-chandler-meetup) event hosted by Intel in Chandler, Arizona on January 15-16.
 
-![alt text][/images/StarlingX_Contributor_Meetup_January_2019.jpg]
+![alt text](/images/StarlingX_Contributor_Meetup_January_2019.jpg)
 
 During the two-day event the attendees discussed - both in person and remotely -  a wide range of topics from release planning through documentation and testing to onboarding. I'd like to give you a short summary of the main topics (as I remember them!) so that you can get up to speed and get involved.
 
@@ -61,7 +61,6 @@ It's a high priority item for the community to reach out to new users as well as
 ## Elections
 
 As the community is setting up the governance models, members decided to choose leaders through an election process. The first election is scheduled for the second quarter of 2019 where five of the Technical Steering Committee (TSC) seats will be up for election. If you're interested in running for the TSC elections, make sure that you are actively participating so the community gets to know you. We're still working on the election process and exact dates, you can check the [governance web page](https://docs.starlingx.io/governance/reference/tsc/index.html) for updates.
-
 
 That's all for my summary. While it may seem like a long list, we had even more discussions and brainstorming sessions over the two days of the meetup. If you have any questions to the above items or if you're interested in trying out the software or getting involved in the community please [reach out](https://www.starlingx.io/community/) on the mailing list or IRC or join one of the weekly community meetings. You can find further details and pointers on the [StarlingX website](https://www.starlingx.io).
 


### PR DESCRIPTION
This change adds the group photo to the blog post that summarizes
the Chandler Contributor Meetup.