### PR TITLE
Community: Add link for Contribute Guides.

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -23,6 +23,7 @@ The StarlingX community has a very active schedule of regular meetings. Details 
 ## Contribute
 
 - Developer guide: [docs.starlingx.io/developer_guide](//docs.starlingx.io/developer_guide)
+- Contribute guides: [docs.starlingx.io/contributor/index.html](//docs.starlingx.io/contributor)
 - Gerrit repo: [git.starlingx.io/cgit](//git.starlingx.io/cgit)
 
 ---


### PR DESCRIPTION
I added a link to the three StarlingX contribute guides
under the "Contribute" heading of the Community page
for the StarlingX website.

Closes-Bug: #1808429

Signed-off-by: Scott Rifenbark <srifenbark@gmail.com>