### PR TITLE
FAQ: Fixed broken sw link and minor typo.

### DIFF
--- a/site/faq/index.md
+++ b/site/faq/index.md
@@ -38,11 +38,11 @@ StarlingX is open source and licensed under the Apache 2.0 license, which means 
 
 #### Where is the code?
 
-StarlingX is free and open source software available through git [git.starlingx.io](git.starlingx.io).
+StarlingX is free and open source software available through Git at [git.starlingx.io](https://git.starlingx.io/cgit).
 
 #### Can I contribute to it? How?
 
-The [StarlingX wiki](https://wiki.openstack.org/wiki/StarlingX) contains documentation for how to download the sourcecode and build it in the "Documentation" section. Code contributions can be made through our[gerrit](https://git.starlingx.io/cgit).
+The [StarlingX wiki](https://wiki.openstack.org/wiki/StarlingX) contains documentation for how to download the sourcecode and build it in the "Documentation" section. Code contributions can be made through our [gerrit](https://git.starlingx.io/cgit) site.
 
 #### How is StarlingX governed?
 


### PR DESCRIPTION
The link to the StarlingX Software under the "Where is the
Code" heading of the FAQ was broken (404).  I added the
correct URL.

Additionally, I spotted a typo in the following section
"Can I Contribute to It? How?" heading.  I fixed that
typo by adding a space and making the sentence end
cleaner.

Closes-Bug: #1808431

Signed-off-by: Scott Rifenbark <srifenbark@gmail.com>