### PR TITLE
Add blog post about Open Infra Summit schedule

### DIFF
--- a/site/blog/starlingx-denver-openinfra-summitschedule-announcement-2019.md
+++ b/site/blog/starlingx-denver-openinfra-summitschedule-announcement-2019.md
@@ -1,0 +1,29 @@
+---
+title: StarlingX featured at Open Infrastructure Summit Denver in April
+author: ildiko-vancsa
+date: 2019-02-20T01:32:05.627Z
+category: news
+---
+Leran more about the Open Infrastructure Summit Denver agenda and program. <!-- more -->
+
+You can meet the StarlingX community at the upcoming [Open Infrastructure Summit](https://www.openstack.org/summit/denver-2019/) in Denver, April 29 - May 1. They will join 30 other open source projects attending the Summit to collaborate in the open. If you want to be part of it too [register now](https://openinfrasummitandptgdenver.eventbrite.com/) before prices increase on February 27.
+
+For 2019, the Summit has expanded and rebranded from the OpenStack Summit to the Open Infrastructure Summit, reflecting the large number of open source tools used to automate modern infrastructure and the challenges of integrating them. The agenda for the event is now live with a full track dedicated to edge computing and features a number of StarlingX talks. 
+
+[View the agenda for the Open Infrastructure Summit Denver](https://www.openstack.org/summit/denver-2019/summit-schedule#day=2019-04-29).
+
+The Summit agenda is organized into 11 tracks: AI/ML/HPC; container infrastructure; CI/CD; edge computing; getting started; open development; private and hybrid cloud; public cloud; security; telecom and NFV; and hands-on workshops.
+
+StarlingX sessions include:
+
+- Precision Time Protocol (PTP) on StarlingX (Matt Peters, Alexander Kozyrev)
+- Getting a new Open Source Project off the ground – the StarlingX story (Ian Jolliffe, Bruce Jones)
+- Edge Computing Group’s MVP Architecture - StarlingX making it real! (Greg Waines, James Penick)
+- 5G-based intelligent manufacturing edge solution (Hong Kan, Jianqing Jiang)
+- StarlingX: Hardened Managed Kubernetes Platform for the Edge (Brent Rowsell, Bart Wensley, Greg Waines)
+
+The StarlingX community will also participate in collaborative sessions offered at the [Forum](https://wiki.openstack.org/wiki/Forum), where open infrastructure operators and upstream developers will gather to jointly chart the long-term future of open source projects. 
+
+Additionally, the team is actively planning their participation at the [Project Teams Gathering](https://www.openstack.org/ptg) (PTG) event that’s co-located with with the Denver Summit at the end of the week. The PTG offers dedicated meeting space for technical communities to have focused project-specific hack time together in person and also to collaborate with adjacent open source communities. You can follow the planning and also sign up if you are interested in attending the sessions [here](https://etherpad.openstack.org/p/stx-ptg-preparation-denver-2019).
+
+Headline sponsors for the Denver Summit are Canonical, Deutsche Telekom and Intel.  [Sponsorships are available](https://www.openstack.org/summit/denver-2019/sponsors/) until April 3. [Contact](mailto:summit@openstack.org) the Summit team with any questions. 


### PR DESCRIPTION
Adding a new blog post to announce the Open Infrastructure Summit
Denver agenda and StarlingX plans and activities during the Forum
and PTG.