### PR TITLE
Add Open Infra Summit STX Workshop blog post

### DIFF
--- a/site/authors/curtis-collicutt.md
+++ b/site/authors/curtis-collicutt.md
@@ -1,0 +1,4 @@
+---
+name: Curtis Collicutt
+company: Interdynamix
+---

--- a/site/blog/starlingx-openinfra-summit-workshop-2019.md
+++ b/site/blog/starlingx-openinfra-summit-workshop-2019.md
@@ -24,6 +24,8 @@ AIO-SX is a single server STX deployment that combines control plane and data pl
 
 At the conclusion of the workshop, students will have a good understanding of what STX is and hands-on experience deploying STX in All-In-One Simplex mode.
 
+If you are interested in joining don't forget to [RSVP](https://www.openstack.org/summit/denver-2019/summit-schedule/events/23630/starlingx-hands-on-workshop) to the workshop to secure your seat. See you in Denver!
+
 ***
 
 Curtis Collicutt is an OpenStack Architect at [Interdynamix](http://www.interdynamix.com), a boutique systems integrator in Canada with a focus on Network Function Virtualization.

--- a/site/blog/starlingx-openinfra-summit-workshop-2019.md
+++ b/site/blog/starlingx-openinfra-summit-workshop-2019.md
@@ -1,0 +1,29 @@
+---
+title:  StarlingX Hands-On Workshop at the OpenInfra Summit
+author: curtis-collicutt
+date: 2019-03-27T01:32:05.627Z
+category: news
+---
+Learn more about the StarlingX Hands-On Workshop at Open Infrastructure Summit Denver. <!-- more -->
+
+StarlingX (STX) is an advanced open source project within the OpenStack Foundation. It combines Kubernetes and OpenStack (yes both!) to form a powerful substrate for applications. The use cases that are possible using StarlingX are varied and numerous, from large OpenStack deployments with many compute nodes and integrated Ceph storage, to single server “edge” nodes for IoT and telecommunications related workloads.
+
+At the upcoming [half-day StarlingX workshop](https://www.openstack.org/summit/denver-2019/summit-schedule/events/23630/starlingx-hands-on-workshop) at the [Open Infrastructure Summit](https://www.openstack.org/summit/denver-2019/) we will answer questions like:
+
+- What is StarlingX? How can I deploy it and use it? 
+- How can I get hands on experience with StarlingX?
+- What are the requirements to deploy STX?
+- How do Kubernetes and OpenStack work together in STX?
+- What is “the edge” and why are OpenStack and StarlingX important to it?
+- How can I deploy a full production instance of OpenStack in as little as a single server?
+- What features does STX have and what design decisions have been made to make deploying and managing OpenStack, and Kubernetes, easier?
+
+In the workshop we will cover the installation of STX in All-in-one Simplex (AIO-SX) mode from an ISO image. Each student will have their own [Packet.com](http://packet.com) provided physical hypervisor in which to deploy a virtual STX AIO-SX node.
+
+AIO-SX is a single server STX deployment that combines control plane and data plane, meaning, for example, that virtual machines created in OpenStack run on the same server as the OpenStack APIs, ie. they are co-located. The AIO-SX deployment will include both Kubernetes and OpenStack, and the workshop will consist of a repeatable, step by step deployment.
+
+At the conclusion of the workshop, students will have a good understanding of what StarlingX is and hands-on experience deploying STX in All-In-One Simplex mode.
+
+***
+
+Curtis Collicutt is an OpenStack Architect at [Interdynamix](http://www.interdynamix.com), a boutique systems integrator in Canada with a focus on Network Function Virtualization.

--- a/site/blog/starlingx-openinfra-summit-workshop-2019.md
+++ b/site/blog/starlingx-openinfra-summit-workshop-2019.md
@@ -1,20 +1,20 @@
 ---
-title:  StarlingX Hands-On Workshop at the OpenInfra Summit
+title:  StarlingX Hands-On Workshop at the Open Infrastructure Summit
 author: curtis-collicutt
 date: 2019-03-27T01:32:05.627Z
 category: news
 ---
 Learn more about the StarlingX Hands-On Workshop at Open Infrastructure Summit Denver. <!-- more -->
 
-StarlingX (STX) is an advanced open source project within the OpenStack Foundation. It combines Kubernetes and OpenStack (yes both!) to form a powerful substrate for applications. The use cases that are possible using StarlingX are varied and numerous, from large OpenStack deployments with many compute nodes and integrated Ceph storage, to single server “edge” nodes for IoT and telecommunications related workloads.
+StarlingX (STX) is an advanced open source project supported by the OpenStack Foundation. It combines Kubernetes and OpenStack (yes both!) to form a powerful substrate for applications. The use cases that are possible using STX are varied and numerous, from large OpenStack deployments with many compute nodes and integrated Ceph storage, to single server “edge” nodes for IoT and telecommunications related workloads.
 
 At the upcoming [half-day StarlingX workshop](https://www.openstack.org/summit/denver-2019/summit-schedule/events/23630/starlingx-hands-on-workshop) at the [Open Infrastructure Summit](https://www.openstack.org/summit/denver-2019/) we will answer questions like:
 
-- What is StarlingX? How can I deploy it and use it? 
-- How can I get hands on experience with StarlingX?
+- What is STX? How can I deploy it and use it? 
+- How can I get hands on experience with STX?
 - What are the requirements to deploy STX?
 - How do Kubernetes and OpenStack work together in STX?
-- What is “the edge” and why are OpenStack and StarlingX important to it?
+- What is “the edge” and why are OpenStack and STX important to it?
 - How can I deploy a full production instance of OpenStack in as little as a single server?
 - What features does STX have and what design decisions have been made to make deploying and managing OpenStack, and Kubernetes, easier?
 
@@ -22,7 +22,7 @@ In the workshop we will cover the installation of STX in All-in-one Simplex (AIO
 
 AIO-SX is a single server STX deployment that combines control plane and data plane, meaning, for example, that virtual machines created in OpenStack run on the same server as the OpenStack APIs, ie. they are co-located. The AIO-SX deployment will include both Kubernetes and OpenStack, and the workshop will consist of a repeatable, step by step deployment.
 
-At the conclusion of the workshop, students will have a good understanding of what StarlingX is and hands-on experience deploying STX in All-In-One Simplex mode.
+At the conclusion of the workshop, students will have a good understanding of what STX is and hands-on experience deploying STX in All-In-One Simplex mode.
 
 ***
 


### PR DESCRIPTION
This commit has a blog post for the upcoming STX Workshop at the Open Infra Summit in Denver.

I've also included a "byline" but it sounded like there would be some potential formatting changes around that, however I thought I'd get the post in as soon as I had it completed and make the necesary changes after initial submission.

Open to any and all changes. :)