### PR TITLE
Adding link to Bitergia metrics

### DIFF
--- a/site/blog/whats-in-it-for-me.md
+++ b/site/blog/whats-in-it-for-me.md
@@ -1,9 +1,10 @@
 ---
-title: Starlingx: What’s in it for you and how to get started
+title: What's in Starlingx for you and how to get started
 author: jeff-gowan
 date: 2019-04-15T01:32:05.627Z
 category: news
 ---
+
 You’ve heard something about StarlingX. Maybe you know StarlingX is a fully-featured open source cloud for the distributed edge. Perhaps you are aware it has features like ultra-low deterministic latency, high availability, strong security, and lowers the cost of deploying and managing a distributed system through simplified installation, maintenance, and operations. You might also understand that it is ideal for telco use cases such as virtualized RAN, universal CPE, MEC and beyond into other use cases in transportation, health care, and industry 4.0.
 
 Now you probably think, “OK, fine. But what about ME? Why should I care about this open source project?” The answer: It depends.

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -23,8 +23,9 @@ The StarlingX community has a very active schedule of regular meetings. Details 
 ## Contribute
 
 - Developer guide: [docs.starlingx.io/developer_resources](https://docs.starlingx.io/developer_resources/index.html)
-- Contributor guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
+- Contribute guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
 - Gerrit repo: [git.starlingx.io/cgit](https://git.starlingx.io/cgit)
+- Contributor metrics: [StarlingX.Biterg.io](https://starlingx.biterg.io/)
 
 ---
 

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -23,7 +23,7 @@ The StarlingX community has a very active schedule of regular meetings. Details 
 ## Contribute
 
 - Developer guide: [docs.starlingx.io/developer_resources](https://docs.starlingx.io/developer_resources/index.html)
-- Contribute guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
+- Contributor guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
 - Gerrit repo: [git.starlingx.io/cgit](https://git.starlingx.io/cgit)
 - Contributor metrics: [StarlingX.Biterg.io](https://starlingx.biterg.io/)
 

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -25,7 +25,6 @@ The StarlingX community has a very active schedule of regular meetings. Details 
 - Developer guide: [docs.starlingx.io/developer_resources](https://docs.starlingx.io/developer_resources/index.html)
 - Contributor guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
 - Gerrit repo: [git.starlingx.io/cgit](https://git.starlingx.io/cgit)
-- Contributor metrics: [StarlingX.Biterg.io](https://starlingx.biterg.io/)
 
 ---
 

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -23,8 +23,9 @@ The StarlingX community has a very active schedule of regular meetings. Details 
 ## Contribute
 
 - Developer guide: [docs.starlingx.io/developer_resources](https://docs.starlingx.io/developer_resources/index.html)
-- Contribute guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
+- Contributor guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
 - Gerrit repo: [git.starlingx.io/cgit](https://git.starlingx.io/cgit)
+- Contributor metrics: [http://starlingx.biterg.io/](http://starlingx.biterg.io/)
 
 ---
 

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -25,7 +25,7 @@ The StarlingX community has a very active schedule of regular meetings. Details 
 - Developer guide: [docs.starlingx.io/developer_resources](https://docs.starlingx.io/developer_resources/index.html)
 - Contributor guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
 - Gerrit repo: [git.starlingx.io/cgit](https://git.starlingx.io/cgit)
-- Contributor metrics: [http://starlingx.biterg.io/](http://starlingx.biterg.io/)
+- Contributor metrics: [StarlingX.Biterg.io](https://starlingx.biterg.io/)
 
 ---
 


### PR DESCRIPTION
Adding the link the the contributor metrics on the Bitergia dashboard.

And changing 'COntribute guides' to 'Contributor guides' to match how the
documents are referred at.