### PR TITLE
Adding info to the community tab

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -23,9 +23,9 @@ The StarlingX community has a very active schedule of regular meetings. Details 
 ## Contribute
 
 - Developer guide: [docs.starlingx.io/developer_resources](https://docs.starlingx.io/developer_resources/index.html)
-- Contribute guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
+- Contributor guides: [docs.starlingx.io/contributor/index.html](https://docs.starlingx.io/contributor)
 - Gerrit repo: [git.starlingx.io/cgit](https://git.starlingx.io/cgit)
-
+- Contributor metrics: [StarlingX.Biterg.io](https://starlingx.biterg.io/)
 ---
 
 ## Wiki


### PR DESCRIPTION
Adding link to the Bitergia community metrics dashboard and change
contribute guides to contributor guides in the same section.