### PR TITLE
Fix the link of starlingx.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StarlingX website
 
-This is the public repo to mantain the StarlingX website at [starlingx.io](starlingx.io).
+This is the public repo to mantain the StarlingX website at [starlingx.io](https://starlingx.io).
 
 ## Overview
 


### PR DESCRIPTION
Add https for starlingx.io, so that it can refer to the expected site.