### PR TITLE
Multiple updates per 2.0 marketing release Doc

### DIFF
--- a/site/.vuepress/components/HomeAnnouncement.vue
+++ b/site/.vuepress/components/HomeAnnouncement.vue
@@ -1,5 +1,5 @@
 <template>
-  <box withActions title="First Release of StarlingX Open Source Edge Cloud Software Now Available">
+  <box withActions title="StarlingX 2.0 Available Now">
 
     <slot></slot>
 

--- a/site/.vuepress/components/HomeContent.vue
+++ b/site/.vuepress/components/HomeContent.vue
@@ -17,7 +17,7 @@
     </base-article>
 
     <base-section class="section-watermark is-dark" containerClass="container-small" withFoot :image="require('../theme/images/watermark.png')">
-      <div class="columns is-multiline">
+      <div class="columns is-multiline" style="padding-top:50px;">
         <div class="column is-one-third values" v-for="value in $page.frontmatter.values">
           <article-small :title="value.title" :image="require('../theme/svg/' + value.icon )">
             <p>{{ value.copy }}</p>

--- a/site/.vuepress/components/hero.vue
+++ b/site/.vuepress/components/hero.vue
@@ -11,7 +11,11 @@
 			<div :class="['container', containerClass]">
 				<div class="hero-content">
 					<h3 class="hero-title">{{ title }}</h3><!-- /.hero-title -->
-
+					<div class="hero-subhead"
+						v-if="['Home'].includes($page.title)"
+			          >Solve the operational problem of deploying and 
+			            <br>managing distributed networks.
+			        </div>
 					<div v-if="withEntry" class="hero-entry">
 						<slot name="entry" />
 					</div><!-- /.hero-entry -->

--- a/site/.vuepress/theme/sass/modules/_box.scss
+++ b/site/.vuepress/theme/sass/modules/_box.scss
@@ -3,7 +3,7 @@
 \* ------------------------------------------------------------ */
 
 .box {
-  padding: 38px 46px 59px;
+  padding: 38px 46px 25px;
   background: #f1f1f1;
   border-radius: 8px;
   box-shadow: none;

--- a/site/.vuepress/theme/sass/modules/_hero.scss
+++ b/site/.vuepress/theme/sass/modules/_hero.scss
@@ -89,9 +89,9 @@
 	text-align: center;
 
 	.hero-title {
-		font-size: 45px;
-		margin-bottom: 35px;
+		font-size: 50px;
 		font-weight: 300;
+		color: #fff;
 	}
 
 	.hero-body {
@@ -138,4 +138,11 @@
 		position: relative;
 		z-index: 10;
 	}
+}
+
+.hero-subhead {
+	font-weight: normal;
+	padding-top: 4px;
+	padding-bottom: 35px;
+	font-size: 18px;
 }

--- a/site/.vuepress/theme/sass/modules/_section.scss
+++ b/site/.vuepress/theme/sass/modules/_section.scss
@@ -159,3 +159,33 @@
 		}
 	}
 }
+
+
+/* ------------------------------------------------------------ *\
+	Software Page
+\* ------------------------------------------------------------ */
+
+.software-icon {
+	float: left;
+	padding-right: 30px;
+	vertical-align: middle;
+}
+
+.box-text{
+	padding-top: 0px;
+}
+
+.video-wrapper {
+	position: relative;
+	padding-bottom: 56.25%; /* 16:9 */
+	padding-top: 25px;
+	height: 0;
+}
+
+.video-wrapper iframe {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}

--- a/site/authors/ian-jolliffe.md
+++ b/site/authors/ian-jolliffe.md
@@ -1,0 +1,5 @@
+---
+name: Ian Jolliffe
+company: Wind River
+---
+

--- a/site/blog/starlingx-second-release-intro-blog.md
+++ b/site/blog/starlingx-second-release-intro-blog.md
@@ -1,0 +1,38 @@
+---
+title:  StarlingX Release 2.0 - Turning everything up side down
+author: ian-jolliffe
+date: 2019-09-03T01:32:05.627Z
+category: news
+---
+Learn more about the StarlingX Hands-On Workshop at Open Infrastructure Summit Denver. <!-- more -->
+
+
+The StarlingX is a relatively new open source project - launched in May of 2018 and things have changed, grown and evolved very quickly. It is a very different project now than when we started for sure.
+
+In the past year we have made a tremendous amount of progress as a community. We have fully operationalized community governance, attracted new contributors from around the world and elected a diverse set of members to the Technical Steering Committee from four different companies. There are a wide range of opportunities for people to contribute to the project, please reach out to us if you are looking to learn more. We have a group of people in our First Contact SIG working to improve the on boarding experience.
+
+At the same time the community has made huge strides in evolving the architecture of the project. In the first release, the platform services ran on bare metal. In this release, the platform has evolved to a Kubernetes based Cloud Native platform, integrating Kubernetes with the StarlingX services. OpenStack components are also leveraged, such as Keystone, Barbican, and Horizon. The containers are deployed via a local docker registry. We now have an ecosystem of components with the StarlingX services ready to drive the convergence of the 5G world. This is a great example of the power of open infrastructure components coming together to solve real problems.
+
+As new technologies emerge it is important to adapt and change to take advantage of the possibilities they bring to the table. At the edge, the solutions are power and space constrained, latency and timing are critical. StarlingX now gives users choice to deploy containers or VM’s or both. OpenStack services are deployed in containers and can be deployed as required for the particular environment. We can now provide an edge optimized solution that brings together Kubernetes and OpenStack.
+
+StarlingX is a project that develops and integrates technologies that brings together a curated solution for Edge use cases. 
+
+The project brings together:
+1.    Growing documentation suite   
+2.    Security
+3.    Ease of deployment
+4.    High performance networking
+5.    Support for highly accurate synchronous timing 
+
+Below are some of the 2.0 updates in these areas:
+
+- We have added significantly to our [documentation](https://docs.starlingx.io) suite and completely refreshed our [wiki](https://wiki.openstack.org/wiki/StarlingX). We have made good progress, and this is an area of continued focus for the project.
+- Support for TPM devices to store secrets, and UEFI secure boot are some examples of the easy ways to leverage security capabilities that are critical at the edge.
+- Deployment is realized by a fully declarative model that leverages Ansible to configure and deploy the initial host environment and software services. We have contributed to and are leveraging Armada and OpenStack Helm to deploy and configure the OpenStack services.
+- From a networking perspective the solution is brought together with either IPv4 or IPv6 full stack support. Calico is the primary CNI, along with Multus and SRIOV to provide high performance (low latency and high throughput) networking capabilities needed at the edge.
+- In this release we have added support for Precision Time Protocol (PTP). This is a great way to source, and distribute a highly accurate clock source to all servers in the cloud. This provides a way to distribute and align a highly accurate clock around a factory or a telecom network, areas where NTP is not accurate enough. 
+- At the same time as the above architectural changes, we have refreshed many components of the stack such as aligning 100% with OpenStack Stein, and updating to Ceph Mimic. In the OpenStack Train release we have contributed to Nova and Neutron and eliminated all out of tree patches.
+
+The StarlingX community has worked tirelessly over the past several months on this exciting transformation. The code and release notes are available here: 
+
+In future blogs, we will go deeper into each of these areas. I hope you find the work we are doing in the community interesting. Your feedback is appreciated, so please join us in this exciting journey transforming computing at the edge and enabling exciting new use cases, in transportation, automation, medical and telecommunications.

--- a/site/blog/starlingx-second-release-intro-blog.md
+++ b/site/blog/starlingx-second-release-intro-blog.md
@@ -4,7 +4,7 @@ author: ian-jolliffe
 date: 2019-09-03T01:32:05.627Z
 category: news
 ---
-Learn more about the StarlingX Hands-On Workshop at Open Infrastructure Summit Denver. <!-- more -->
+Learn more about the new StarlingX 2.0 release. <!-- more -->
 
 
 The StarlingX is a relatively new open source project - launched in May of 2018 and things have changed, grown and evolved very quickly. It is a very different project now than when we started for sure.

--- a/site/blog/starlingx-second-release-intro-blog.md
+++ b/site/blog/starlingx-second-release-intro-blog.md
@@ -9,15 +9,15 @@ Learn more about the new StarlingX 2.0 release. <!-- more -->
 
 The StarlingX is a relatively new open source project - announced in May of 2018 and things have changed, grown and evolved very quickly. It is a very different project now than when we started for sure.
 
-In the past year we have made a tremendous amount of progress as a community. We have fully operationalized community governance, attracted new contributors from around the world, and elected a diverse set of members to the Technical Steering Committee from four different companies. There are a wide range of opportunities for people to contribute to the project; please reach out to us if you are looking to learn more. We have a group of people in our First Contact SIG working to improve the on boarding experience.
+In the past year we have made a tremendous amount of progress as a community. We have fully operationalized community governance, attracted new contributors from around the world, and elected a diverse set of members to the Technical Steering Committee from four different companies. There are a wide range of opportunities for people to contribute to the project; please reach out to us if you are looking to learn more. We have a group of people in our [First Contact SIG](https://wiki.openstack.org/wiki/StarlingX/First_Contact_SIG) working to improve the on boarding experience.
 
-At the same time the community has made huge strides in evolving the architecture of the project. In the first release, the platform services ran on bare metal. In this release, the platform has evolved to a Kubernetes-based Cloud Native platform, integrating Kubernetes with the StarlingX services. OpenStack components are also leveraged, such as Keystone, Barbican, and Horizon. The containers are deployed via a local docker registry. We now have an ecosystem of components with the StarlingX services ready to drive the convergence of the 5G world. This is a great example of the power of open infrastructure components coming together to solve real problems.
+At the same time the community has made huge strides in evolving the architecture of the project. In the first release, the platform services ran on bare metal. In this release, the platform has evolved to a cloud native platform integrating OpenStack and Kubernetes with the StarlingX services. The containers are deployed via a local docker registry. We now have an ecosystem of components with the StarlingX services ready to drive the convergence of the 5G world. This is a great example of the power of open infrastructure components coming together to solve real problems.
 
-As new technologies emerge it is important to adapt and change to take advantage of the possibilities they bring to the table. At the edge, the solutions are power and space constrained, latency and timing are critical. StarlingX now gives users choice to deploy containers or VM’s or both. OpenStack services are deployed in containers and can be deployed as required for the particular environment. We can now provide an edge optimized solution that brings together Kubernetes and OpenStack.
+As new technologies emerge it is important to adapt and change to take advantage of the possibilities they bring to the table. At the edge, the solutions are power and space constrained, latency and timing are critical. StarlingX now gives users the choice to deploy containers or VM’s or both. OpenStack services are deployed in containers that gives more flexibility to shape the platform for the requirements of a particular environment. We can now provide an edge optimized solution that brings together Kubernetes and OpenStack.
 
 StarlingX is a project that develops and integrates technologies that brings together a curated solution for Edge use cases. 
 
-The project brings together:
+Among other features the project provides:
 1.    Growing documentation suite   
 2.    Security
 3.    Ease of deployment
@@ -33,6 +33,6 @@ Below are some of the StarlingX 2.0 updates in these areas:
 - In this release we have added support for Precision Time Protocol (PTP). This is a great way to source, and distribute a highly accurate clock source to all servers in the cloud. This provides a way to distribute and align a highly accurate clock around a factory or a telecom network, areas where NTP is not accurate enough. 
 - At the same time as the above architectural changes, we have refreshed many components of the stack such as aligning 100% with OpenStack Stein, and updating to Ceph Mimic. In the OpenStack Train release we have contributed to Nova and Neutron and eliminated all out of tree patches.
 
-The StarlingX community has worked tirelessly over the past several months on this exciting transformation. The code and release notes are available here: 
+The StarlingX community has worked tirelessly over the past several months on this exciting transformation. See the [release notes](https://docs.starlingx.io/releasenotes/index.html#release-notes) for more information or check the [code](https://opendev.org/starlingx) to start you journey with StarlingX.
 
 In future blogs, we will go deeper into each of these areas. I hope you find the work we are doing in the community interesting. Your feedback is appreciated, so please join us in this exciting journey transforming computing at the edge and enabling exciting new use cases, in transportation, automation, medical and telecommunications.

--- a/site/blog/starlingx-second-release-intro-blog.md
+++ b/site/blog/starlingx-second-release-intro-blog.md
@@ -7,11 +7,11 @@ category: news
 Learn more about the new StarlingX 2.0 release. <!-- more -->
 
 
-The StarlingX is a relatively new open source project - launched in May of 2018 and things have changed, grown and evolved very quickly. It is a very different project now than when we started for sure.
+The StarlingX is a relatively new open source project - announced in May of 2018 and things have changed, grown and evolved very quickly. It is a very different project now than when we started for sure.
 
-In the past year we have made a tremendous amount of progress as a community. We have fully operationalized community governance, attracted new contributors from around the world and elected a diverse set of members to the Technical Steering Committee from four different companies. There are a wide range of opportunities for people to contribute to the project, please reach out to us if you are looking to learn more. We have a group of people in our First Contact SIG working to improve the on boarding experience.
+In the past year we have made a tremendous amount of progress as a community. We have fully operationalized community governance, attracted new contributors from around the world, and elected a diverse set of members to the Technical Steering Committee from four different companies. There are a wide range of opportunities for people to contribute to the project; please reach out to us if you are looking to learn more. We have a group of people in our First Contact SIG working to improve the on boarding experience.
 
-At the same time the community has made huge strides in evolving the architecture of the project. In the first release, the platform services ran on bare metal. In this release, the platform has evolved to a Kubernetes based Cloud Native platform, integrating Kubernetes with the StarlingX services. OpenStack components are also leveraged, such as Keystone, Barbican, and Horizon. The containers are deployed via a local docker registry. We now have an ecosystem of components with the StarlingX services ready to drive the convergence of the 5G world. This is a great example of the power of open infrastructure components coming together to solve real problems.
+At the same time the community has made huge strides in evolving the architecture of the project. In the first release, the platform services ran on bare metal. In this release, the platform has evolved to a Kubernetes-based Cloud Native platform, integrating Kubernetes with the StarlingX services. OpenStack components are also leveraged, such as Keystone, Barbican, and Horizon. The containers are deployed via a local docker registry. We now have an ecosystem of components with the StarlingX services ready to drive the convergence of the 5G world. This is a great example of the power of open infrastructure components coming together to solve real problems.
 
 As new technologies emerge it is important to adapt and change to take advantage of the possibilities they bring to the table. At the edge, the solutions are power and space constrained, latency and timing are critical. StarlingX now gives users choice to deploy containers or VM’s or both. OpenStack services are deployed in containers and can be deployed as required for the particular environment. We can now provide an edge optimized solution that brings together Kubernetes and OpenStack.
 
@@ -24,7 +24,7 @@ The project brings together:
 4.    High performance networking
 5.    Support for highly accurate synchronous timing 
 
-Below are some of the 2.0 updates in these areas:
+Below are some of the StarlingX 2.0 updates in these areas:
 
 - We have added significantly to our [documentation](https://docs.starlingx.io) suite and completely refreshed our [wiki](https://wiki.openstack.org/wiki/StarlingX). We have made good progress, and this is an area of continued focus for the project.
 - Support for TPM devices to store secrets, and UEFI secure boot are some examples of the easy ways to leverage security capabilities that are critical at the edge.

--- a/site/faq/index.md
+++ b/site/faq/index.md
@@ -6,9 +6,9 @@ title: FAQs
 
 <ul class="list-disc">
   <li>A fully open source solution that is ready to deploy</li>
-  <li>StarlingX's is optimizing cloud services for edge solutions</li>
-  <li>StarlingX focuses on security, ultra-low latency, extremely high service uptime, small-footprint deployments and streamlined operations.</li>
-  <li>The open source origins of StarlingX derive from a proven, deployed, broad-scale commercial offering that has been open sourced</li>
+  <li>Flexibility to run on containers, VMs, and/or Bare Metal</li>
+  <li>Optimize cloud services for edge solutions</li>
+  <li>Security, ultra-low latency, extremely high service uptime, small-footprint deployments and streamlined operations</li>
   <li>Suitable for a wide range of edge applications</li>
 </ul>
 
@@ -26,11 +26,11 @@ StarlingX integrates a number of upstream projects: CentOS, OvS-DPDK, Ceph, Kube
 
 #### What is the operating system
 
-StarlingX is integrating and tested with CentOS and team is already working on multiOS support. Contributions are welcome!
+StarlingX is integrating and tested with CentOS and the team is already working on multiOS support. Contributions are welcome!
 
 #### How do I get started testing StarlingX?
 
-The [StarlingX wiki](https://wiki.openstack.org/wiki/StarlingX) contains documentation for how to download the sourcecode, build and test it in the "Documentation" section.
+The [StarlingX wiki](https://wiki.openstack.org/wiki/StarlingX) contains documentation for how to download the source code, then build and test it, in the "Documentation" section.
 
 #### What's the license for StarlingX?
 
@@ -38,7 +38,7 @@ StarlingX is open source and licensed under the Apache 2.0 license, which means 
 
 #### Where is the code?
 
-StarlingX is free and open source software available through Git at [opendev.org/starlingx](https://opendev.org/starlingx).
+StarlingX is free and open source software. Start here: [opendev.org/starlingx](https://opendev.org/starlingx)
 
 #### Can I contribute to it? How?
 
@@ -64,9 +64,9 @@ StarlingX is a top-level pilot project supported by the OpenStack Foundation, bu
 
 The StarlingX team is actively working with a number of other projects and communities, both within and outside of the OpenStack Foundation projects. The community is contributing to the Nova, Horizon, Keystone and Neutron projects within OpenStack. Our teams are also involved in the OSF Edge Computing Group as well as the Akraino community and the EdgeXFoundry project.
 
-#### When is the first release of StarlingX?
+#### When is the next release of StarlingX?
 
-The first release will be in October 2018. The project will release on a 4 month cadence each March, July and November in 2019. Releases are time based.
+The first release was in October 2018. The next release is in August 2019. 
 
 #### Are there any commercial distributions of StarlingX?
 

--- a/site/faq/index.md
+++ b/site/faq/index.md
@@ -64,9 +64,9 @@ StarlingX is a top-level pilot project supported by the OpenStack Foundation, bu
 
 The StarlingX team is actively working with a number of other projects and communities, both within and outside of the OpenStack Foundation projects. The community is contributing to the Nova, Horizon, Keystone and Neutron projects within OpenStack. Our teams are also involved in the OSF Edge Computing Group as well as the Akraino community and the EdgeXFoundry project.
 
-#### When is the next release of StarlingX?
+#### What is the release cadence for StarlingX?
 
-The first release was in October 2018. The next release is in August 2019. 
+The initial (beta) StarlingX release was released in October 2018. In 2019 and moving forward, StarlingX releases will align with OpenStack releases. StarlingX will have two releases a year, following a cycle-trailing model relative to the OpenStack release cycle.
 
 #### Are there any commercial distributions of StarlingX?
 

--- a/site/footer-nav.json
+++ b/site/footer-nav.json
@@ -47,7 +47,7 @@
         },
         {
           "text": "Documentation",
-          "link": "https://wiki.openstack.org/wiki/StarlingX"
+          "link": "https://docs.starlingx.io/"
         }
       ]
     }

--- a/site/index.md
+++ b/site/index.md
@@ -1,20 +1,20 @@
 ---
 layout: Home
-title: StarlingX
+title: Home
 
 hero:
-  headline: A fully featured cloud for the distributed edge
+  headline: Deploy your edge cloud now
   button:
-    title: View The Code
-    url: //opendev.org/starlingx
+    title: Get Started Now
+    url: /software/
 
 values:
-  - title: Reliability
+  - title: Reliabile
     icon: check-large.svg
     copy: |
       Fault management, fast secure VM failover and live migration minimizes downtime
 
-  - title: Scalability
+  - title: Scalable
     icon: scale.svg
     copy: |
       Deployable on one to thousands of distributed nodes allowing for a single system to be used from edge to core
@@ -29,7 +29,7 @@ values:
     copy: |
       Deterministic, tunable performance optimized for the use case
 
-  - title: Edge security
+  - title: Secure
     icon: lock.svg
     copy: |
       Software security to avoid tampering at the edge, where physical security may be limited
@@ -63,7 +63,7 @@ getInvolvedSteps:
 
 ## About StarlingX
 
-StarlingX is a complete cloud infrastructure software stack for the edge used by the most demanding applications in industrial IOT, telecom, video delivery and other ultra-low latency use cases. Based on mature software deployed for mission critical applications, newly open sourced StarlingX code is the base for edge implementations in scalable solutions that is ready for production now.
+StarlingX is a complete cloud infrastructure software stack for the edge used by the most demanding applications in industrial IOT, telecom, video delivery and other ultra-low latency use cases. With deterministic low latency required by edge applications, and tools that make distributed edge manageable, StarlingX provides a container-based infrastructure for edge implementations in scalable solutions that is ready for production now.
 
 <a href="/learn/" class="link is-primary">Learn More ></a>
 
@@ -71,7 +71,7 @@ StarlingX is a complete cloud infrastructure software stack for the edge used by
 
 <home-announcement slot="announcement" button-name="Read the blog post" link="/blog/starlingx-initial-release.html">
 
-StarlingX—the open source edge computing and IoT cloud platform optimized for low latency and high performance applications—is now available in its first release. The project was established in May as a pilot project supported by the OpenStack Foundation (OSF) and builds on code contributed by Wind River and Intel.
+StarlingX Release 2.0 is now available. The open source edge computing and IoT cloud platform optimized for low latency and high performance applications is now a container based platfom for hosting OpenStack and other cloud native applications.
 
 </home-announcement>
 

--- a/site/index.md
+++ b/site/index.md
@@ -5,11 +5,11 @@ title: Home
 hero:
   headline: Deploy your edge cloud now
   button:
-    title: Get Started Now
+    title: Get Started
     url: /software/
 
 values:
-  - title: Reliabile
+  - title: Reliable
     icon: check-large.svg
     copy: |
       Fault management, fast secure VM failover and live migration minimizes downtime

--- a/site/index.md
+++ b/site/index.md
@@ -71,7 +71,7 @@ StarlingX is a complete cloud infrastructure software stack for the edge used by
 
 <home-announcement slot="announcement" button-name="Read the blog post" link="/blog/starlingx-initial-release.html">
 
-StarlingX Release 2.0 is now available. The open source edge computing and IoT cloud platform optimized for low latency and high performance applications is now a container based platfom for hosting OpenStack and other cloud native applications.
+StarlingX Release 2.0 is now available. The open source edge computing and IoT cloud platform optimized for low latency and high performance applications is now a container based platform for hosting OpenStack and other cloud native applications.
 
 </home-announcement>
 

--- a/site/index.md
+++ b/site/index.md
@@ -69,7 +69,7 @@ StarlingX is a complete cloud infrastructure software stack for the edge used by
 
 </template>
 
-<home-announcement slot="announcement" button-name="Read the blog post" link="/blog/starlingx-initial-release.html">
+<home-announcement slot="announcement" button-name="Read the blog post" link="/blog/starlingx-second-release-intro-blog.html">
 
 StarlingX Release 2.0 is now available. The open source edge computing and IoT cloud platform optimized for low latency and high performance applications is now a container based platform for hosting OpenStack and other cloud native applications.
 

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -17,7 +17,7 @@ streamlined operation.
 
 **[Read the StarlingX Project Overview deck](/collateral/StarlingX-Onboarding-Deck-for-Web-February-2019.pdf)**
 
-**[Watch the OSF Community Webinar dedicated to StarlingX onboarding](https://www.youtube.com/watch?v=G9uwGnKD6tM&t)**
+**[StarlingX Videos](https://www.youtube.com/playlist?list=PLKqaoAnDyfgp7KWad7EAHnZ30Mdg3Ejqf)**
 
 ---
 

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -3,6 +3,13 @@ description: An overview of the StarlingX project
 title: Learn
 ---
 
+<div class="video-wrapper">
+  <iframe width="835 px" height="469.687 px" src="https://www.youtube.com/embed/videoseries?list=PLKqaoAnDyfgp7KWad7EAHnZ30Mdg3Ejqf" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+<br>
+<br>
+
 The StarlingX virtualization platform focuses on easy deployment, low touch manageability, rapid response to events and
 fast recovery -- think control at the edge, control between IoT and cloud, and control over your virtual machines.
 

--- a/site/software/index.md
+++ b/site/software/index.md
@@ -3,22 +3,37 @@ description: Development activities in StarlingX
 title: Software
 ---
 
+<div class="video-wrapper">
+  <iframe width="835 px" height="469.687 px" src="https://www.youtube.com/embed/ImoTABqtdF8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+<br>
+<br>
+
 StarlingX is an integration and development project to provide a full software stack suitable to fulfill the strict requirements of edge computing use cases from security to high availability. Beyond integrating well known open source components such as OpenStack modules, Kubernetes, Ceph, OVS-DPDK, and so forth the community is working on new services to fill in the gaps in the open source ecosystem to enhance deployment, maintainability and operation of the software components.
 
 <div class="columns">
   <div class="column">
     <div class="box is-purple">
-      <h3>Get StarlingX</h3>
-      <a href="https://opendev.org/starlingx">
-        Go to opendev.org/starlingx >
+      <h3>Install the latest image</h3>
+      <a href="http://mirror.starlingx.cengn.ca/mirror/starlingx/release/">
+        mirror.starlingx.cengn.ca
       </a>
     </div>
   </div>
   <div class="column">
     <div class="box is-purple">
-      <h3>View the Documentation</h3>
+      <h3>Get the source code</h3>
+      <a href="https://opendev.org/starlingx">
+        opendev.org/starlingx
+      </a>
+    </div>
+  </div>
+  <div class="column">
+    <div class="box is-purple">
+      <h3>View the documentation</h3>
       <a href="https://docs.starlingx.io">
-        Go to docs.starlingx.io >
+        docs.starlingx.io
       </a>
     </div>
   </div>


### PR DESCRIPTION
General update notes:

- Homepage edits for 2.0 messaging
- FAQ updates to clarify 2.0 release
- Software page - add video, clean up columns
- Learn - clean up and messaging updates

Referencing the attached word doc:

P1 
-- Home -Integration of open source section not included until we get signoff on logo usage
-- Home - New diagram not available as yet

P3
-- Home - New blogpost not available, so not yet linked
-- Learn - I kind of disagree about adding a subnav to a page that basically links to links within the same page that only link to other pages (Videos, FAQ). Perhaps we can discuss options?

P4
-- Learn - For StarlingX Videos - I went ahead and linked straight to our YouTube playlist. Let me know what you think.
-- Learn - Echoing above, I think adding new sections that just link off to other sections is a mistake. IMO we should rely on the top navigation for this unless there is some compelling reason to highlight it within relevant text.

P5
-- Software - I added a video at the top of the page to mirror the Airship site. Let me know what you think here? Can be updated to whatever.
-- Software - Three column callouts under the first paragraphs... I'm not super happy with the layout here. Consider it a placeholder for now.  Open to suggestions.
-- Software - Have not added "latest diagram" yet. Waiting for this update.



Signed-off-by: Jimmy McArthur <jimmy@tipit.net>