### PR TITLE
Change OpenStack Foundation name to Open Infrastructure Foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "starlingx-website",
   "description": "www.starlingx.io",
   "version": "1.0.0",
-  "author": "OpenStack Foundation",
+  "author": "Open Infrastructure Foundation",
   "dependencies": {
     "@ncwidgets/file-relation": "^0.5.0",
     "@ncwidgets/id": "^0.5.1",

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -45,7 +45,7 @@ const Footer = class extends React.Component {
                 <div className="footer-aside">
                   <div className="footer-entry">
                     <p>
-                      StarlingX is an independent open source community collaboratively developing code under the Apache 2 license. The project is supported by the OpenStack Foundation; the community follows the OpenStack Foundation <OutboundLink href="https://www.openstack.org/legal/community-code-of-conduct/" target="_blank" rel="noopener noreferrer">Code of Conduct</OutboundLink>.
+                      StarlingX is an independent open source community collaboratively developing code under the Apache 2 license. The project is supported by the Open Infrastructure Foundation; the community follows the Open Infrastructure Foundation <OutboundLink href="https://www.openstack.org/legal/community-code-of-conduct/" target="_blank" rel="noopener noreferrer">Code of Conduct</OutboundLink>.
                     </p>
                   </div> 
                   <div className="footer-brand">

--- a/src/pages/community/index.md
+++ b/src/pages/community/index.md
@@ -59,6 +59,6 @@ Technical decisions will be made by technical contributors and a representative 
 
 ## Code of Conduct
 
-Our community follows the OpenStack Foundation [Code of Conduct](https://www.openstack.org/legal/community-code-of-conduct/).
+Our community follows the Open Infrastructure Foundation [Code of Conduct](https://www.openstack.org/legal/community-code-of-conduct/).
 
 

--- a/src/pages/faq/index.md
+++ b/src/pages/faq/index.md
@@ -63,11 +63,11 @@ Yes, here are links to templates for both [Keynote](https://www.starlingx.io/col
 
 #### Is this an OpenStack project?
 
-StarlingX is a top-level Open Infrastructure project supported by the OpenStack Foundation, but is not a part of the OpenStack cloud infrastructure project. From a technical perspective StarlingX is both a development and integration project, which includes and uses many of the OpenStack services as well as other open source projects. Some of those projects are enhanced in the StarlingX build. The StarlingX community is actively working with upstream communities to contribute these changes.
+StarlingX is a top-level Open Infrastructure project supported by the Open Infrastructure Foundation, but is not a part of the OpenStack cloud infrastructure project. From a technical perspective StarlingX is both a development and integration project, which includes and uses many of the OpenStack services as well as other open source projects. Some of those projects are enhanced in the StarlingX build. The StarlingX community is actively working with upstream communities to contribute these changes.
 
 #### How does the StarlingX community collaborate with other open source projects?
 
-The StarlingX team is actively working with a number of other projects and communities, both within and outside of the OpenStack Foundation projects. The community is contributing to the Nova, Horizon, Keystone and Neutron projects within OpenStack. Our teams are also involved in the OSF Edge Computing Group as well as the Akraino community and the EdgeXFoundry project.
+The StarlingX team is actively working with a number of other projects and communities, both within and outside of the Open Infrastructure Foundation projects. The community is contributing to the Nova, Horizon, Keystone and Neutron projects within OpenStack. Our teams are also involved in the OSF Edge Computing Group as well as the Akraino community and the EdgeXFoundry project.
 
 #### What is the release cadence for StarlingX?
 

--- a/src/pages/supporters/index.md
+++ b/src/pages/supporters/index.md
@@ -131,5 +131,5 @@ donors:
 
 ---
 
-StarlingX is an open source community stewarded by the OpenStack Foundation (OSF).
+StarlingX is an open source community stewarded by the Open Infrastructure Foundation (OSF).
 


### PR DESCRIPTION
Signed-off-by: Ildiko Vancsa <ildiko.vancsa@gmail.com>