### PR TITLE
Add link to blog contribution guidelines

### DIFF
--- a/src/content/blog-config.json
+++ b/src/content/blog-config.json
@@ -32,5 +32,11 @@
       "text": "Twitter",
       "link": "https://twitter.com/starlingx"
     }
+  ],
+  "share": [
+    {
+      "text": "How to Contribute a Blog Post",
+      "link": "https://docs.starlingx.io/contributor/blog_contribute_guide.html"
+    }
   ]
 }

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -79,6 +79,16 @@ export default class BlogIndexPage extends React.Component {
                         </ul>
                       </div>
                     </li>
+                    <li className="widget item-no-bullet">
+                      <div className="widget-head">
+                        <h6 className="widget-title">Share Your Story</h6>
+                      </div>
+                      <div className="widget-body">
+                        <ul className="widget-list">
+                          {blogConfig.share.map(link => <li><a href={link.link} target="_blank" rel="noopener noreferrer">{link.text}</a></li>)}
+                        </ul>
+                      </div>
+                    </li>
                   </ul>
                 </aside>            
               </div>


### PR DESCRIPTION
This patch adds a link to the new description in the StarlingX
docs about how to contribute a new blog post to the website.

Signed-off-by: Ildiko Vancsa <ildiko.vancsa@gmail.com>