### PR TITLE
Add low-latency demo link

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -58,8 +58,8 @@ values:
       text: |
         Deterministic, tunable performance optimized for the use case
       title: Ultra-low latency
-      link: 
-      linkText: 
+      link: https://www.youtube.com/embed/ZfFdnaQB8eE
+      linkText: Watch Video
     - image: /img/lock.svg
       text: >
         Software security to avoid tampering at the edge, where physical


### PR DESCRIPTION
This patch adds a pointer to the new low-latency demo video
that is hosted on Youtube and added to the StarlingX playlist.

Signed-off-by: Ildiko Vancsa <ildiko.vancsa@gmail.com>