### PR TITLE
Replace video on SW page to newer one

### DIFF
--- a/src/pages/software/index.md
+++ b/src/pages/software/index.md
@@ -10,7 +10,7 @@ seo:
 title: Software
 subTitle: Development activities in StarlingX
 intro:
-  video: https://www.youtube.com/embed/Hs8bp8NSYAM?list=PLKqaoAnDyfgo5sOi98QlbMVMhgI_lxFPA&start=1200
+  video: https://www.youtube.com/embed/72DhrYFIon8
   text: >
     StarlingX is an integration and development project to provide a full software stack suitable 
     to fulfill the strict requirements of edge computing use cases from security to high 


### PR DESCRIPTION
This patch replaces the embedded video on the software tab
to a newer presentation about the platform.

Signed-off-by: Ildiko Vancsa <ildiko.vancsa@gmail.com>