### PR TITLE
Fix 7.0 blog publish date

### DIFF
--- a/src/pages/blog/starlingx-release-7.md
+++ b/src/pages/blog/starlingx-release-7.md
@@ -2,7 +2,7 @@
 templateKey: blog-post
 title: StarlingX R7.0 is here!
 author: Ildiko Vancsa
-date: 2022-08-01T01:32:05.627Z
+date: 2022-09-13T01:32:05.627Z
 category: 
   - label: News & Announcements
     id: category-A7fnZYrE1


### PR DESCRIPTION
The publish date of the 7.0 release overview blog post was incorrect. This patch fixes that.

Signed-off-by: Ildiko Vancsa <ildiko.vancsa@gmail.com>