### PR TITLE
Updating image mirror links

### DIFF
--- a/src/pages/blog/starlingx-certificate-lcm.md
+++ b/src/pages/blog/starlingx-certificate-lcm.md
@@ -67,4 +67,4 @@ StarlingX now also supports the orchestration of the Kubernetes Root CA certific
 
 For the complete list of updates and new features in StarlingX 6.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r6_release.html) and the [project documentation](https://docs.starlingx.io).
 
-Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/) to try out the new features.

--- a/src/pages/blog/starlingx-debian-technology-preview-in-release-7.md
+++ b/src/pages/blog/starlingx-debian-technology-preview-in-release-7.md
@@ -307,4 +307,4 @@ those for StarlingX release 7.0 based on CentOS.
 
 For the complete list of updates and new features in StarlingX R7.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r7-0-release-notes-bc72d0b961e7.html) and the [project documentation](https://docs.starlingx.io/).
 
-Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/) to try out the new features.

--- a/src/pages/blog/starlingx-enabling-the-intelligent-edge.md
+++ b/src/pages/blog/starlingx-enabling-the-intelligent-edge.md
@@ -32,4 +32,4 @@ StarlingX is designed for applications where critical systems need to co-exist w
  
 From connecting smartphones to connecting cars, StarlingX has a bright future in front of it. If you have an industry use case that you believe could benefit from StarlingX or if you just want to be part of a growing developer community that’s helping to build a better future, reach out on the [starlingx-discuss mailing list](https://lists.starlingx.io/mailman3/lists/starlingx-discuss.lists.starlingx.io/), or the [StarlingX General chat room on Matrix](https://matrix.to/#/#starlingx:opendev.org).
 
-Visit the StarlingX [website](https://www.starlingx.io) today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX [website](https://www.starlingx.io) today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/) to try out the new features.

--- a/src/pages/blog/starlingx-oran-o2-application.md
+++ b/src/pages/blog/starlingx-oran-o2-application.md
@@ -84,4 +84,4 @@ The O-RAN specification compliant O2 Interfaces feature is just one example of S
 
 For the complete list of updates and new features in StarlingX 8.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r8-0-release-notes-6a6ef57f4d99.html) and the [project documentation](https://docs.starlingx.io).
 
-Visit the StarlingX [website](https://www.starlingx.io) today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX [website](https://www.starlingx.io) today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/) to try out the new features.

--- a/src/pages/blog/starlingx-release-3.md
+++ b/src/pages/blog/starlingx-release-3.md
@@ -51,4 +51,4 @@ To summarize, StarlingX 3.0 provides a cloud platform that scales from a single 
 
 For the complete list of updates and new features in StarlingX 3.0 check out the [release notes](https://docs.starlingx.io/releasenotes/r3_release.html) and further [documentation](https://docs.starlingx.io) of the project.
 
-Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/) to try out the new features.

--- a/src/pages/blog/starlingx-release-4.md
+++ b/src/pages/blog/starlingx-release-4.md
@@ -32,4 +32,4 @@ As in all release cycles, there are a few components that have new versions avai
 
 For the complete list of updates and new features in StarlingX R4.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r4_release.html) and the [project documentation](https://docs.starlingx.io).
 
-Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/) to try out the new features.

--- a/src/pages/blog/starlingx-release-5.md
+++ b/src/pages/blog/starlingx-release-5.md
@@ -35,4 +35,4 @@ If you install the latest version of the platform you will also get features and
 
 For the complete list of updates and new features in StarlingX R5.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r5_release.html) and the [project documentation](https://docs.starlingx.io).
 
-Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/5.0.0/centos/flock/outputs/) to try out the new features.
+Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/5.0.0/centos/flock/outputs/) to try out the new features.

--- a/src/pages/blog/starlingx-release-6.md
+++ b/src/pages/blog/starlingx-release-6.md
@@ -36,4 +36,4 @@ Another enhancement in the area of security to highlight is the support of 'audi
 
 For the complete list of updates and new features in StarlingX R6.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r6-0-release-notes-bc72d0b961e7.html) and the [project documentation](https://docs.starlingx.io/).
 
-Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/ to try out the new features.

--- a/src/pages/blog/starlingx-release-7.md
+++ b/src/pages/blog/starlingx-release-7.md
@@ -30,4 +30,4 @@ The community has also been focusing on security enhancements, such as the suppo
 
 For the complete list of updates and new features in StarlingX R7.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r7-0-release-notes-85446867da2a.html) and the [project documentation](https://docs.starlingx.io/).
 
-Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/) to try out the new features.

--- a/src/pages/blog/starlingx-release-8.md
+++ b/src/pages/blog/starlingx-release-8.md
@@ -33,4 +33,4 @@ To further support the low-latency and distributed cloud requirements of edge co
 
 For the complete list of updates and new features in StarlingX R8.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r8-0-release-notes-6a6ef57f4d99.html) and the [project documentation](https://docs.starlingx.io/).
 
-Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX website today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/ to try out the new features.

--- a/src/pages/blog/starlingx-single-core-platform.md
+++ b/src/pages/blog/starlingx-single-core-platform.md
@@ -59,4 +59,4 @@ For further information about the feature, refer to the project documentation [S
 
 For the complete list of updates and new features in StarlingX 8.0, check out the [release notes](https://docs.starlingx.io/releasenotes/r8-0-release-notes-6a6ef57f4d99.html) and the [project documentation](https://docs.starlingx.io).
 
-Visit the StarlingX [website](https://www.starlingx.io) today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](http://mirror.starlingx.cengn.ca/mirror/starlingx/release/) to try out the new features.
+Visit the StarlingX [website](https://www.starlingx.io) today for further information about the project, check out the [code](https://opendev.org/starlingx), or download the [latest image](https://mirror.starlingx.windriver.com/mirror/starlingx/release/) to try out the new features.

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -12,7 +12,7 @@ header:
   buttons:
     - link: /software/
       text: Get Started
-    - link: http://mirror.starlingx.cengn.ca/mirror/starlingx/release/
+    - link: https://mirror.starlingx.windriver.com/mirror/starlingx/release/
       text: Download ISO
     - link: /community/
       text: Get Help

--- a/src/pages/software/index.md
+++ b/src/pages/software/index.md
@@ -21,8 +21,8 @@ intro:
   columns:
     - title: Install the latest image
       link:
-        text: mirror.starlingx.cengn.ca
-        url: http://mirror.starlingx.cengn.ca/mirror/starlingx/release/
+        text: mirror.starlingx.windriver.com
+        url: https://mirror.starlingx.windriver.com/mirror/starlingx/release/
     - title: Get the source code
       link: 
         text: opendev.org/starlingx


### PR DESCRIPTION
CENGN is no longer providing the image mirrors to the Starlingx project.

This patch updates the links to point to the new mirror site that is provided by Wind River.