### PR TITLE
Update remark ga track links version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gatsby-plugin-sass": "^2.2.0",
     "gatsby-plugin-sharp": "^2.5.1",
     "gatsby-remark-copy-linked-files": "^2.2.0",
-    "gatsby-remark-google-analytics-track-links": "^0.0.6",
+    "gatsby-remark-google-analytics-track-links": "^1.0.2",
     "gatsby-remark-images": "^3.2.0",
     "gatsby-remark-images-medium-zoom": "^1.4.0",
     "gatsby-remark-relative-images": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7293,12 +7293,12 @@ gatsby-remark-copy-linked-files@^2.2.0:
     probe-image-size "^6.0.0"
     unist-util-visit "^1.4.1"
 
-gatsby-remark-google-analytics-track-links@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-google-analytics-track-links/-/gatsby-remark-google-analytics-track-links-0.0.6.tgz#e9749fcb23dd41b0e055083b9352f6c6aaa20aa5"
-  integrity sha512-S6kAqIf47qsBMyetuJOOhYtjmed2oPV0+m+GIPuumXYCbSctYdrLMcu+51VhH29ixyt/a0d5RhV3vGcDuCBwVg==
+gatsby-remark-google-analytics-track-links@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-google-analytics-track-links/-/gatsby-remark-google-analytics-track-links-1.0.2.tgz#4416f948f0e180ccecb26142cfb482e81e2f4520"
+  integrity sha512-EPyelkHIDwBQAr2Qfp7rFEF449tQjuuEM++rCcfVqbFt+UzmY0atrx3UNxXCTe6uSL1UA/Lt4tFeEjgu6nw9oA==
   dependencies:
-    unist-util-visit "2.0.2"
+    unist-util-visit "2.0.3"
 
 gatsby-remark-images-medium-zoom@^1.4.0:
   version "1.7.0"
@@ -11451,10 +11451,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-navigation-widget@^1.0.14:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/navigation-widget/-/navigation-widget-1.0.14.tgz#8a00b09d861482c5fdf80e14765694b099ccc9f7"
-  integrity sha512-q3NukJInay6yWwmkJe7wdsBX4SrRKeyxaueVnVZqJbdwZYpHxWRMZqoGSDBXtNZAe5p35iruWZ5F7m6RfqCIlQ==
+navigation-widget@^1.0.16:
+  version "1.0.27"
+  resolved "https://registry.yarnpkg.com/navigation-widget/-/navigation-widget-1.0.27.tgz#1f84bba8bd81ff34f01ea8b476bcb2c27a9fc867"
+  integrity sha512-JXB0xF3sJI2b1STnS3ak9stpIXzaQZmhPw26yf1ELx8h+UPyyRTD3NW+23ZNMqGkx+X3cH3Za94GQ2KWbovchQ==
 
 needle@^2.5.2:
   version "2.9.1"
@@ -17018,10 +17018,10 @@ unist-util-visit-parents@^5.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
-unist-util-visit@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.2.tgz#3843782a517de3d2357b4c193b24af2d9366afb7"
-  integrity sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==
+unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
+  integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
@@ -17033,15 +17033,6 @@ unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.4.1:
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
   dependencies:
     unist-util-visit-parents "^2.0.0"
-
-unist-util-visit@^2.0.0, unist-util-visit@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
-  integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-is "^4.0.0"
-    unist-util-visit-parents "^3.0.0"
 
 unist-util-visit@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Update `gatsby-remark-google-analytics-track-links` to include this fix https://github.com/jamessimone/gatsby-remark-google-analytics-track-links/commit/d6a27187f9dd389fdaa8a2ac1dcd1398e71c4536 that was causing errors on this deploy  #263

ref: https://tipit.avaza.com/project/view/188886#!tab=task-pane&task=3537116

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>