### PR TITLE
Fix typo in blog title

### DIFF
--- a/src/pages/blog/starlingx-apparmor.md
+++ b/src/pages/blog/starlingx-apparmor.md
@@ -1,6 +1,6 @@
 ---
 templateKey: blog-post
-title: Securing application using AppArmor
+title: Securing Applications Using AppArmor
 author: Jagatguru Mishra
 date: 2024-05-20T01:32:05.627Z
 


### PR DESCRIPTION
This patch fixes camel casing and a typo in the title of the AppArmor blog post that was published in May, 2024..