### PR TITLE
Update the website footer

### DIFF
--- a/src/content/footer-nav.json
+++ b/src/content/footer-nav.json
@@ -56,6 +56,10 @@
         {
           "text": "Documentation",
           "link": "https://docs.starlingx.io/"
+        },
+        {
+          "text": "Security vulnerabilities",
+          "link": "https://wiki.openstack.org/wiki/StarlingX/Security#How_to_report_security_issues_to_StarlingX"
         }
       ]
     }


### PR DESCRIPTION
This patch adds a link to the vulnerability reporting process in the footer of the website, to make it easier for people to discover.